### PR TITLE
Use Config instead of env() for OpenAI API key

### DIFF
--- a/app/Services/PricingService.php
+++ b/app/Services/PricingService.php
@@ -15,7 +15,7 @@ class PricingService
     public function __construct()
     {
         $this->config = Config::get('laracloud');
-        $this->apiKey = env('OPENAI_API_KEY');
+        $this->apiKey = Config::get('services.openai.api_key');
         // TODO: Allow region selection if needed in the future
     }
 

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+    ],
+
 ];


### PR DESCRIPTION
To avoid issues when configuration is cached

![image](https://github.com/user-attachments/assets/2ff08022-2d5d-4515-a1ea-b1d3964b90f6)
